### PR TITLE
DS-970: Add Magic Nix Cache and other workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - uses: codespell-project/codespell-problem-matcher@v1
     - name: Check Spelling
       run: nix develop --command codespell .
@@ -22,6 +23,7 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Terraform fmt
         run: nix-shell --run 'terraform fmt -check -recursive ./terraform'
       - name: Terraform init
@@ -34,6 +36,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Check Formatting
       run: nix develop --command nixpkgs-fmt .
 
@@ -42,6 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Evaluate ZFS
       run: nix-instantiate . -A images.zfs.x86_64-linux
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,9 +8,13 @@ jobs:
   lockfile:
     runs-on: ubuntu-22.04
     steps:
-      - name: Update flake.lock
+      - name: Checkout
         uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: DeterminateSystems/flake-checker-action@main
-      - uses: DeterminateSystems/update-flake-lock@main
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Check flake
+        uses: DeterminateSystems/flake-checker-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,16 +1,16 @@
 name: update-flake-lock
 on:
   workflow_dispatch:
-#   schedule:
-#     - cron: '0 0 * * 0'
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   lockfile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v16
+        uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+      - uses: DeterminateSystems/update-flake-lock@main


### PR DESCRIPTION
 An assortment of GitHub Workflow changes, potentially including:

- Enable DeterminateSystems/magic-nix-cache-action@main
- Reference all DeterminateSystems actions via @main
- Make update.yaml consistent across repos
- Remove unnecessary github-token: from nix-installer-action
- Update actions/checkout@v2 to actions/checkout@v3
